### PR TITLE
Create output directory if not exist

### DIFF
--- a/src/Controllers/ConverterController.vala
+++ b/src/Controllers/ConverterController.vala
@@ -251,7 +251,7 @@ namespace Ciano.Controllers {
          */
         private void start_conversion_process (ItemConversion item, string name_format) {
             try {
-                var directory = File.new_for_path (item.directory);
+                var directory = File.new_for_path (this.settings.output_folder);
                 if (!directory.query_exists ()) {
                     directory.make_directory_with_parents();
                 }


### PR DESCRIPTION
Instead of trying to create the source directory, which must be already exist.