### PR TITLE
Add launchable tag to appdata

### DIFF
--- a/data/com.github.robertsanseries.ciano.appdata.xml.in
+++ b/data/com.github.robertsanseries.ciano.appdata.xml.in
@@ -2,6 +2,7 @@
 <!-- Copyright 2017 Robert San <robertsanseries@gmail.io> -->
 <component type="desktop-application">
     <id>com.github.robertsanseries.ciano</id>
+    <launchable type="desktop-id">com.github.robertsanseries.ciano.desktop</launchable>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0+</project_license>
     <name>Ciano</name>


### PR DESCRIPTION
This is needed for appstream-generator to find the associated desktop file.

See also:
- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
- https://github.com/ximion/appstream-generator/issues/88