### PR TITLE
Add Flatpak manifest for elementary OS 6

### DIFF
--- a/com.github.robertsanseries.ciano.yml
+++ b/com.github.robertsanseries.ciano.yml
@@ -1,0 +1,93 @@
+app-id: com.github.robertsanseries.ciano
+
+runtime: io.elementary.Platform
+runtime-version: '6'
+sdk: io.elementary.Sdk
+
+command: com.github.robertsanseries.ciano
+
+finish-args:
+  - '--share=ipc'
+  - '--socket=x11'
+  - '--socket=wayland'
+  - '--filesystem=home'
+  - '--metadata=X-DConf=migrate-path=/com/github/robertsanseries/ciano/'
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/vala
+  - /share/gir-1.0
+  - /share/gtk-doc
+  - /lib/girepository-1.0
+  - /lib/*.la
+
+modules:
+  - name: imagemagick
+    config-opts:
+      - '--enable-static=no'
+      - '--disable-docs'
+      - '--disable-deprecated'
+      - '--without-autotrace'
+      - '--without-bzlib'
+      - '--without-djvu'
+      - '--without-dps'
+      - '--without-fftw'
+      - '--without-fontconfig'
+      - '--without-fpx'
+      - '--without-freetype'
+      - '--without-gvc'
+      - '--without-jbig'
+      - '--without-jpeg'
+      - '--without-lcms'
+      - '--without-lzma'
+      - '--without-magick-plus-plus'
+      - '--without-openexr'
+      - '--without-openjp2'
+      - '--without-pango'
+      - '--without-raqm'
+      - '--without-tiff'
+      - '--without-webp'
+      - '--without-wmf'
+      - '--without-x'
+      - '--without-xml'
+      - '--without-zlib'
+    sources:
+      - type: archive
+        url: https://github.com/ImageMagick/ImageMagick/archive/7.0.11-6.tar.gz
+        sha256: 8adc1605784653b078572b825e8cd1d3d54f8a1b4ba86b32ca253c038f7e4c37
+
+  - name: chrpath
+    cleanup:
+      - '*'
+    sources:
+      - type: archive
+        url: http://deb.debian.org/debian/pool/main/c/chrpath/chrpath_0.16.orig.tar.gz
+        sha256: bb0d4c54bac2990e1bdf8132f2c9477ae752859d523e141e72b3b11a12c26e7b
+
+  - name: ffmpeg
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/ffmpeg/examples
+    config-opts:
+      - '--enable-shared'
+      - '--disable-static'
+      - '--disable-ffplay'
+      - '--disable-ffprobe'
+      - '--disable-doc'
+      - '--disable-network'
+    post-install:
+      - chrpath -d /app/bin/ffmpeg
+    sources:
+      - type: archive
+        url: https://ffmpeg.org/releases/ffmpeg-4.4.tar.xz
+        sha256: 06b10a183ce5371f915c6bb15b7b1fffbe046e8275099c96affc29e17645d909
+
+  - name: ciano
+    buildsystem: meson
+    config-opts:
+      - '--buildtype=release'
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
Closes #129.

I used your Flathub manifest and adapted it for elementary OS 6 platform.

Tried converting a couple of videos; works okay.